### PR TITLE
Leading space before comment edge case

### DIFF
--- a/toml.lua
+++ b/toml.lua
@@ -1053,7 +1053,7 @@ TOML.multistep_parser = function(options)
 		while (bounds()) do
 			-- skip comments and whitespace
 			-- Only treat # as comment if we're not in the middle of parsing a key
-			if char() == "#" and (buffer == "" or quotedKey) then
+			if char() == "#" and (trim(buffer) == "" or quotedKey) then
 				while (bounds() and not matchnl()) do
 					step()
 				end


### PR DESCRIPTION
Consider the following TOML:
```toml
[data.good] # This comment is good
somedata = 0
# This comment is also good

[data.bad]
     # This comment is bad
```
This text would yield `Error parsing TOML: At TOML line 6: Invalid key.` This PR simply adjusts the check for comments to account for whitespace.

```diff
-- parse the document!
while (bounds()) do
    -- skip comments and whitespace
    -- Only treat # as comment if we're not in the middle of parsing a key
-   if char() == "#" and (buffer == "" or quotedKey) then
+   if char() == "#" and (trim(buffer) == "" or quotedKey) then
```